### PR TITLE
[FTP-2] FTP File Resolution/Verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ MODULE.bazel.lock
 .DS_Store
 bazel-CloudMesh
 
-data
+data/*

--- a/include/utility.h
+++ b/include/utility.h
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <netinet/in.h>
 #include <random>
+#include <regex>
 #include <sstream>
 #include <stdio.h>
 #include <stdlib.h>
@@ -63,5 +64,17 @@ int FTP_create_socket_client(int port, const char* addr);
 int FTP_create_socket_server(int port);
 
 int FTP_accept_conn(int sock);
+
+/*
+ * Resolves the path of a file within the data directory.
+ * Accepts a filename and returns a relative path.
+ */
+fs::path resolveDataFile(const std::string filename);
+
+/*
+ * Verifies if a file is present in the data directory. Accepts
+ * a filename as input.
+ */
+bool isFileWithinDataDirectory(const std::string& filename);
 
 #endif // __UTILITY__

--- a/src/Networking/client.cpp
+++ b/src/Networking/client.cpp
@@ -96,13 +96,22 @@ int Client::sendMsg(const char* data) {
         int datasock, lSize, num_blks, num_last_blk, i;
         FILE* fp;
         cout << "FTP: Filename given is: " << filename << endl;
+
+        if (!isFileWithinDataDirectory(filename)) {
+            cerr << "FTP: Requested file is not within the data directory"
+                 << endl;
+            send(CONN, "0", FTP_BUFFER_SIZE, 0);
+            close(CONN);
+            return 1;
+        }
+
         int data_port = 1024;
         sprintf(port, "%d", data_port);
         datasock = FTP_create_socket_server(
             data_port); // creating socket for data connection
         send(CONN, port, FTP_BUFFER_SIZE, 0); // sending port no. to client
         datasock = FTP_accept_conn(datasock); // accepting connnection by client
-        if ((fp = fopen(filename.c_str(), "r")) != NULL) {
+        if ((fp = fopen(resolveDataFile(filename).c_str(), "r")) != NULL) {
             // size of file
             send(CONN, "nxt", FTP_BUFFER_SIZE, 0);
             fseek(fp, 0, SEEK_END);

--- a/src/Networking/server.cpp
+++ b/src/Networking/server.cpp
@@ -96,7 +96,7 @@ void Server::getFileFTP(string filename) {
     datasock = FTP_create_socket_client(data_port, PORT);
     recv(activeConn, msg, FTP_BUFFER_SIZE, 0);
     if (strcmp("nxt", msg) == 0) {
-        if ((fp = fopen(filename.c_str(), "w")) == NULL)
+        if ((fp = fopen(resolveDataFile(filename).c_str(), "w")) == NULL)
             cout << "FTP: Error in creating file" << endl;
         else {
             recv(activeConn, char_num_blks, FTP_BUFFER_SIZE, 0);

--- a/src/Peers/requester.cpp
+++ b/src/Peers/requester.cpp
@@ -89,9 +89,7 @@ void Requester::divideTask() {
 
         // Build a path by combining the filename and DATA_DIR using path joins
         string filename = "subtaskData_" + std::to_string(i) + ".txt";
-        fs::path path = fs::path(DATA_DIR) / filename;
-
-        TaskRequest subtaskRequest = TaskRequest(1, subtaskData, path.string());
+        TaskRequest subtaskRequest = TaskRequest(1, subtaskData, filename);
         /*
          * We use FTP to send the training data. This is necessary if the
          * training data is large or cannot be easily serialized into an in
@@ -118,9 +116,7 @@ void Requester::divideTask() {
 
         // Build a path by combining the filename and DATA_DIR using path joins
         string filename = "subtaskData_" + std::to_string(numSubtasks) + ".txt";
-        fs::path path = fs::path(DATA_DIR) / filename;
-
-        TaskRequest subtaskRequest = TaskRequest(1, subtaskData, path.string());
+        TaskRequest subtaskRequest = TaskRequest(1, subtaskData, filename);
         cout << "FTP: Created file " << subtaskRequest.getTrainingFile()
              << endl;
         subtaskRequest.setLeaderUuid(queuedTask.getLeaderUuid());

--- a/src/RequestResponse/task_request.cpp
+++ b/src/RequestResponse/task_request.cpp
@@ -36,9 +36,10 @@ void TaskRequest::setTrainingFile(const string& trainingFile) {
 }
 
 void TaskRequest::setTrainingDataFromFile() {
-    ifstream file(trainingFile);
+    fs::path path = resolveDataFile(trainingFile);
+    ifstream file(path.string());
     if (!file.is_open()) {
-        cerr << "Error opening file: " << trainingFile << endl;
+        cerr << "Error opening file: " << path.string() << endl;
         return;
     }
 
@@ -51,9 +52,10 @@ void TaskRequest::setTrainingDataFromFile() {
 }
 
 void TaskRequest::createTrainingFile() {
-    ofstream file(trainingFile);
+    fs::path path = resolveDataFile(trainingFile);
+    ofstream file(path.string());
     if (!file.is_open()) {
-        cerr << "Error opening file: " << trainingFile << endl;
+        cerr << "Error opening file: " << path.string() << endl;
         return;
     }
 

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -205,3 +205,24 @@ int FTP_accept_conn(int sock) {
 
     return (dataconnfd);
 }
+
+fs::path resolveDataFile(const std::string filename) {
+    std::string resolvedFilename = DATA_DIR + "/" + filename;
+    return fs::path(resolvedFilename);
+}
+
+bool isFileWithinDataDirectory(const std::string& filename) {
+    std::regex cloudmeshDataPattern(".*cloudmesh/" + std::string(DATA_DIR) +
+                                        ".*",
+                                    std::regex_constants::icase);
+
+    try {
+        fs::path requestedPath = resolveDataFile(filename);
+        std::string canonicalPathStr =
+            fs::canonical(fs::absolute(requestedPath)).string();
+        return std::regex_search(canonicalPathStr, cloudmeshDataPattern);
+    } catch (const std::exception& e) {
+        std::cerr << "Caught Error: " << e.what() << std::endl;
+        return false; // Invalid path format or not within the data directory
+    }
+}


### PR DESCRIPTION
It is necessary to verify the file requested is available and within the specific data/ directory. This change ensures that peers communicate with reference to filenames, and all file access will be **resolved** against the data directory. This is safer compared to directly serializing paths sent by unknown peers.

Additionally, this PR introduces a very simple path validation mechanism that ensures requested paths contain the directory pattern `cloudmesh/data`, with case insensitivity. This change prevents access to files outside of the designated data directory, helping enforce security boundaries for file requests.


Testing:
![Screenshot of Visual Studio Code on 2024-11-02 at 00 37 09@2x](https://github.com/user-attachments/assets/e681df00-6eb7-4b95-b929-75431838089f)
![Screenshot of Visual Studio Code on 2024-11-02 at 01 05 28@2x](https://github.com/user-attachments/assets/63691e93-9214-4ba1-8f1b-a64e0cf4c6b6)

