### PR TITLE
[FTP] Multiple Provider Bug Fix

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,3 +2,4 @@ build --cxxopt=-std=c++20
 build --copt=-Wall
 build --copt=-pthread
 build --linkopt=-lpthread
+build:macos --copt=-mmacosx-version-min=10.15

--- a/README.md
+++ b/README.md
@@ -10,15 +10,25 @@ Follow this to install bazel - https://bazel.build/install
 ## Compilation
 
 To compile **BOOTSTRAP**, **PROVIDER** and **REQUESTER**, run the following commands:
+### MacOS
 ```
-bazel build //...
+bazel build //... --experimental_google_legacy_api --config=macos
+```
+### Windows
+```
+bazel build //... --experimental_google_legacy_api
 ```
 
 ## Compilation (Local)
 
 To compile **BOOTSTRAP**, **PROVIDER** and **REQUESTER** locally, run the following commands:
+### MacOS
 ```
-bazel build //... --define local=true
+bazel build //... --define local=true --experimental_google_legacy_api --config=macos
+```
+### Windows
+```
+bazel build //... --define local=true --experimental_google_legacy_api
 ```
 
 ## Execution

--- a/include/utility.h
+++ b/include/utility.h
@@ -24,6 +24,10 @@ namespace fs = std::filesystem;
  */
 #define FTP_BUFFER_SIZE 4096
 
+#define MIN_PORT 49152
+#define MAX_PORT 65535
+#define MAX_PORT_TRIES 10
+
 /*
  * Defines the data location of training files.
  */
@@ -76,5 +80,11 @@ fs::path resolveDataFile(const std::string filename);
  * a filename as input.
  */
 bool isFileWithinDataDirectory(const std::string& filename);
+
+/*
+ * Generates a random port number that is available for use between MIN_PORT and
+ * MAX_PORT.
+ */
+int get_available_port();
 
 #endif // __UTILITY__

--- a/main.cpp
+++ b/main.cpp
@@ -11,15 +11,10 @@ using namespace std;
 
 int main(int argc, char* argv[]) {
     const char* port = "8080";
-    string uuid = "1";
+    string uuid = uuid::generate_uuid_v4();
 
     if (argc >= 2) {
         port = argv[1];
-    }
-
-    // PURELY FOR DEMO PURPOSES. FOLLOWER PEER IS HARD CODED TO PORT 8081
-    if (strcmp(port, "8081")) {
-        uuid = "2";
     }
 
 #if defined(BOOTSTRAP)
@@ -34,6 +29,7 @@ int main(int argc, char* argv[]) {
 #elif defined(REQUESTER)
     cout << "Running as requester." << endl;
     Requester r = Requester(port);
+    int numRequestedWorkers = 3;
 
     string requestType = "c";
     if (argc >= 3) {
@@ -42,7 +38,7 @@ int main(int argc, char* argv[]) {
 
     if (requestType == "c") {
         vector<int> trainingData{2, 1, 4, 3, 6, 5, 9, 7, 8, 10};
-        TaskRequest request = TaskRequest(1, trainingData); // just one provider
+        TaskRequest request = TaskRequest(numRequestedWorkers, trainingData);
         r.setTaskRequest(request);
         // sends the task request to the leader and provider peers
         r.sendTaskRequest();

--- a/src/Networking/client.cpp
+++ b/src/Networking/client.cpp
@@ -105,7 +105,12 @@ int Client::sendMsg(const char* data) {
             return 1;
         }
 
-        int data_port = 1024;
+        int data_port = get_available_port();
+        if (data_port == -1) {
+            cerr << "FTP: No available ports" << endl;
+            return 1;
+        }
+        cout << "FTP: Data port is: " << data_port << endl;
         sprintf(port, "%d", data_port);
         datasock = FTP_create_socket_server(
             data_port); // creating socket for data connection

--- a/src/Networking/client.cpp
+++ b/src/Networking/client.cpp
@@ -108,6 +108,8 @@ int Client::sendMsg(const char* data) {
         int data_port = get_available_port();
         if (data_port == -1) {
             cerr << "FTP: No available ports" << endl;
+            send(CONN, "0", FTP_BUFFER_SIZE, 0);
+            close(CONN);
             return 1;
         }
         cout << "FTP: Data port is: " << data_port << endl;

--- a/src/Peers/provider.cpp
+++ b/src/Peers/provider.cpp
@@ -160,7 +160,16 @@ void Provider::followerHandleTaskRequest() {
     while (client->setupConn(leaderIp, "tcp") == -1) {
         sleep(5);
     }
-    client->sendMsg(task->serialize().c_str());
+
+    // send results back to leader
+    shared_ptr<TaskResponse> payload =
+        make_shared<TaskResponse>(task->getTrainingData());
+    Message msg(uuid, IpAddress(host, port), payload);
+
+    // keep trying to send results back to leader
+    while (client->sendMsg(msg.serialize().c_str()) != 0) {
+        sleep(5);
+    }
 }
 
 void Provider::processWorkload() {

--- a/src/Peers/requester.cpp
+++ b/src/Peers/requester.cpp
@@ -83,12 +83,13 @@ void Requester::divideTask() {
     vector<TaskRequest> subtasks;
     for (int i = 0; i < numSubtasks; i++) {
         vector<int> subtaskData;
+        int currentSubtaskSize = subtaskSize;
 
         if (i == numSubtasks - 1) {
-            subtaskSize += remainder;
+            currentSubtaskSize += remainder;
         }
 
-        for (int j = 0; j < subtaskSize; j++) {
+        for (int j = 0; j < currentSubtaskSize; j++) {
             subtaskData.push_back(trainingData[i * subtaskSize + j]);
         }
 

--- a/src/Peers/requester.cpp
+++ b/src/Peers/requester.cpp
@@ -66,7 +66,7 @@ void Requester::divideTask() {
     // divide the large task into subtasks
     // divide "[2, 1, 4, 3, 6, 5, 9, 7, 8, 10]" into as many subtasks as
     // there
-    TaskRequest queuedTask = taskRequests[0];
+    TaskRequest queuedTask = taskRequests.front();
 
     // parse string array as vector
     vector<int> trainingData = queuedTask.getTrainingData();
@@ -83,13 +83,18 @@ void Requester::divideTask() {
     vector<TaskRequest> subtasks;
     for (int i = 0; i < numSubtasks; i++) {
         vector<int> subtaskData;
+
+        if (i == numSubtasks - 1) {
+            subtaskSize += remainder;
+        }
+
         for (int j = 0; j < subtaskSize; j++) {
             subtaskData.push_back(trainingData[i * subtaskSize + j]);
         }
 
         // Build a path by combining the filename and DATA_DIR using path joins
         string filename = "subtaskData_" + std::to_string(i) + ".txt";
-        TaskRequest subtaskRequest = TaskRequest(1, subtaskData, filename);
+        TaskRequest subtaskRequest(1, subtaskData, filename);
         /*
          * We use FTP to send the training data. This is necessary if the
          * training data is large or cannot be easily serialized into an in
@@ -105,26 +110,7 @@ void Requester::divideTask() {
         taskRequests.push_back(subtaskRequest);
     }
 
-    // add the remainder to the last subtask
-    // TODO: this implementation looks wrong. Should add to last subtask instead
-    // of creating a new one.
-    if (remainder != 0) {
-        vector<int> subtaskData;
-        for (int i = 0; i < remainder; i++) {
-            subtaskData.push_back(trainingData[numSubtasks * subtaskSize + i]);
-        }
-
-        // Build a path by combining the filename and DATA_DIR using path joins
-        string filename = "subtaskData_" + std::to_string(numSubtasks) + ".txt";
-        TaskRequest subtaskRequest = TaskRequest(1, subtaskData, filename);
-        cout << "FTP: Created file " << subtaskRequest.getTrainingFile()
-             << endl;
-        subtaskRequest.setLeaderUuid(queuedTask.getLeaderUuid());
-        subtaskRequest.setAssignedWorkers(queuedTask.getAssignedWorkers());
-        taskRequests.push_back(subtaskRequest);
-    }
-
-    // remove the large task request
+    // remove the task request
     taskRequests.erase(taskRequests.begin());
 }
 

--- a/src/RequestResponse/task_request.cpp
+++ b/src/RequestResponse/task_request.cpp
@@ -53,6 +53,8 @@ void TaskRequest::setTrainingDataFromFile() {
 
 void TaskRequest::createTrainingFile() {
     fs::path path = resolveDataFile(trainingFile);
+    // create the directory
+    fs::create_directories(path.parent_path());
     ofstream file(path.string());
     if (!file.is_open()) {
         cerr << "Error opening file: " << path.string() << endl;

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -226,3 +226,29 @@ bool isFileWithinDataDirectory(const std::string& filename) {
         return false; // Invalid path format or not within the data directory
     }
 }
+
+int get_available_port() {
+    std::random_device random_num_generator;
+    std::mt19937 gen(random_num_generator());
+    std::uniform_int_distribution<> dis(MIN_PORT, MAX_PORT);
+
+    for (int i = 0; i < MAX_PORT_TRIES; i++) {
+        int port = dis(gen);
+        int sock = socket(AF_INET, SOCK_STREAM, 0);
+        if (sock < 0)
+            continue;
+
+        struct sockaddr_in addr;
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = INADDR_ANY;
+        addr.sin_port = htons(port);
+
+        if (::bind(sock, (struct sockaddr*)&addr, sizeof(addr)) == 0) {
+            close(sock);
+            return port;
+        }
+
+        close(sock);
+    }
+    return -1;
+}


### PR DESCRIPTION
FTP bug fix for multiple providers

Things added -
1. `get_available_port();` function - This will get a random **VALID** port number in between MIN_PORT and MAX_PORT. It will retry to get a port MAX_PORT_TRIES number of times
2. Removed hard coded UUID's from main.ccp
3. Fixed code to send results back to the leader peer from the follower
4. Fixed issue with uneven subtask division
5. Creating the directory for the FTP file in case it doesn't exist
6. Updated `.bazelrc` so code works with MacOS computers. Updated the README as well