### PR TITLE
[GLOB_INDEX-1] Refactor TaskRequest to support glob patterns and index filenames

### DIFF
--- a/include/RequestResponse/task_request.h
+++ b/include/RequestResponse/task_request.h
@@ -12,36 +12,31 @@ class TaskRequest : public Payload {
     unsigned int numWorkers;
     std::string leaderUuid;
     AddressTable assignedWorkers;
-    // A task request can have the training data as an array of integers
-    std::vector<int> trainingData;
-    // A task request can have a string that specifies the
-    // name of the training file on the local filesystem
-    std::string trainingFile;
-    // Creates a file containing the trainingData as trainingFile, in the
-    // DATA_DIR directory. Only for demo purposes.
-    // In a real-world scenario, the training data
-    // should be provided and this function will be obsolete.
-    void createTrainingFile();
+    // A globPattern for the names of the training
+    // data files necessitates the creation of
+    // training data index files
+    std::string globPattern;
+    // Each transported task request should contain an index
+    // file that contains the names of the training data files
+    std::string trainingDataIndexFilename;
 
   public:
+    // Tagged "union" (to-do: c++17 supports variant class)
+    enum TaskRequestType { NONE, GLOB_PATTERN, INDEX_FILENAME } taskRequestType;
     TaskRequest();
-    TaskRequest(const unsigned int numWorkers,
-                const std::vector<int>& trainingdata);
-    TaskRequest(const unsigned int numWorkers,
-                const std::vector<int>& trainingdata,
-                const std::string& trainingFileName);
+    TaskRequest(const unsigned int numWorkers, const std::string& data,
+                TaskRequestType type);
 
     void setLeaderUuid(const std::string& leaderUuid);
     void setAssignedWorkers(const AddressTable& assignedWorkers);
-    void setTrainingData(const std::vector<int>& trainingData);
-    void setTrainingFile(const std::string& trainingFile);
-    void setTrainingDataFromFile();
+    void setGlobPattern(const std::string& pattern);
+    void setTrainingDataIndexFilename(const std::string& filename);
 
     unsigned int getNumWorkers() const;
-    std::vector<int> getTrainingData() const;
     std::string getLeaderUuid() const;
     AddressTable getAssignedWorkers() const;
-    std::string getTrainingFile() const;
+    std::string getGlobPattern() const;
+    std::string getTrainingDataIndexFilename() const;
 
     google::protobuf::Message* serializeToProto() const override;
     void deserializeFromProto(

--- a/main.cpp
+++ b/main.cpp
@@ -41,8 +41,9 @@ int main(int argc, char* argv[]) {
     }
 
     if (requestType == "c") {
-        vector<int> trainingData{2, 1, 4, 3, 6, 5, 9, 7, 8, 10};
-        TaskRequest request = TaskRequest(numRequestedWorkers, trainingData);
+        TaskRequest request =
+            TaskRequest(numRequestedWorkers, "subtaskData_.*\\.txt$",
+                        TaskRequestType::GLOB_PATTERN);
         r.setTaskRequest(request);
         // sends the task request to the leader and provider peers
         r.sendTaskRequest();

--- a/proto/payload.proto
+++ b/proto/payload.proto
@@ -37,8 +37,10 @@ message TaskRequest {
     int32 numWorkers = 1;
     string leaderUuid = 2;
     utility.AddressTable assignedWorkers = 3;
-    repeated int32 trainingData = 4;
-    string trainingFile = 5;
+    oneof training_data_source {
+        string glob_pattern = 4;
+        string training_data_index_filename = 5;
+    }
 }
 
 message TaskResponse { repeated int32 trainingData = 1; }


### PR DESCRIPTION
This pull request introduces changes to the `TaskRequest` class and related files to improve the handling of training data sources. The changes include replacing the use of raw training data vectors with more flexible data source types: glob patterns and index filenames.

**glob patterns:**  used to specify a to be determined set of training files to include as part of the task request
**index filename**: used to indicate a specific set of training files associated with the task request