### PR TITLE
[GLOB_INDEX-2] Update task request and response processing in requester and provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ To execute, run the following commands:
 `r` is an optional parameter to request to receive the result of the computation (use same port as original request execution)
 `c` is an optional parameter to request to provide the computation
 
+
+### Resources
+
+The peers assume data is located in the directory specified by
+the `DATA_DIR` parameter in `utility.h`. All filenames and globbing 
+options are taken w.r.t the `DATA_DIR` parameter.
+
 ## Tests
 A few unit tests are available. They can be run with
 ```bash

--- a/include/Peers/provider.h
+++ b/include/Peers/provider.h
@@ -17,7 +17,8 @@ class Provider : public Peer {
     bool isBusy;
     bool isLocalBootstrap;
     bool isLeader;
-    std::unique_ptr<TaskRequest> task;
+    std::unique_ptr<TaskRequest> taskRequest;
+    std::unique_ptr<TaskResponse> taskResponse;
     ZMQSender zmq_sender;
     ZMQReceiver zmq_receiver;
 
@@ -31,6 +32,8 @@ class Provider : public Peer {
     void followerHandleTaskRequest();
     void processData();
     void processWorkload(); // worker function to manipulate the TaskRequest
+    std::vector<int>
+    ingestTrainingData(); // worker function to load training data into memory
     TaskResponse aggregateResults(std::vector<std::vector<int>> followerData);
 };
 

--- a/include/RequestResponse/task_request.h
+++ b/include/RequestResponse/task_request.h
@@ -31,6 +31,8 @@ class TaskRequest : public Payload {
     void setAssignedWorkers(const AddressTable& assignedWorkers);
     void setGlobPattern(const std::string& pattern);
     void setTrainingDataIndexFilename(const std::string& filename);
+    void writeToTrainingDataIndexFile(
+        const std::vector<std::string>& trainingDataFiles) const;
 
     unsigned int getNumWorkers() const;
     std::string getLeaderUuid() const;
@@ -38,6 +40,8 @@ class TaskRequest : public Payload {
     std::string getGlobPattern() const;
     std::string getTrainingDataIndexFilename() const;
 
+    // Retrieves all data files referenced in this task request
+    std::vector<std::string> getTrainingDataFiles() const;
     google::protobuf::Message* serializeToProto() const override;
     void deserializeFromProto(
         const google::protobuf::Message& protoMessage) override;

--- a/main.cpp
+++ b/main.cpp
@@ -42,8 +42,8 @@ int main(int argc, char* argv[]) {
 
     if (requestType == "c") {
         TaskRequest request =
-            TaskRequest(numRequestedWorkers, "subtaskData_.*\\.txt$",
-                        TaskRequestType::GLOB_PATTERN);
+            TaskRequest(numRequestedWorkers, ".*subtaskData_.*\\.txt$",
+                        TaskRequest::GLOB_PATTERN);
         r.setTaskRequest(request);
         // sends the task request to the leader and provider peers
         r.sendTaskRequest();

--- a/src/RequestResponse/task_response.cpp
+++ b/src/RequestResponse/task_response.cpp
@@ -8,6 +8,10 @@ TaskResponse::TaskResponse(const vector<int>& trainingData)
 
 vector<int> TaskResponse::getTrainingData() const { return trainingData; }
 
+void TaskResponse::setTrainingData(const vector<int>& trainingData) {
+    this->trainingData = trainingData;
+}
+
 google::protobuf::Message* TaskResponse::serializeToProto() const {
     payload::TaskResponse* proto = new payload::TaskResponse();
 


### PR DESCRIPTION
Operation:
1. A `globbing` type task request is specified in `main.cpp` for a requester. 
2. The requester scans all files that match the glob and seperates into `n` groups, where `n` is number of workers
3. The requester creates `n` index files to store these filenames and send it 
4. The provider gets an index file name, FTP fetch it locally, then iteratively FTP fetch each non-locally available file referenced inthe index.

Changed: 
* division of task requeset now takes all training files and partitions them in to `n` index files, where `n` is the number of workers
* provider now expects an `index` type file
* create fn `ingestTrainingData` will download all training data specified by the `index` file, and injest them. for our current workflow, this is just reading the training data line by line into a `vector<int>`

Tested to compile and work across three providers.

![Screenshot of Code on 2024-12-10 at 13 34 45@2x](https://github.com/user-attachments/assets/f19a2002-33c9-4baa-8669-2a416d805234)
