### PR TITLE
ZMQ Ports Automatic Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,9 @@ To execute, run the following commands:
 
 ### Provider
 ```
-./bazel-bin/provider [8080] [5555]
+./bazel-bin/provider [8080]
 ``` 
 (8080 is the default port, optional parameter)
-`5555` is the default ZeroMQ port. We need to change this for different providers with a gap of 2: 5555, 5557, 5559, ....
 
 ### Requester
 

--- a/include/IPC/zmq_receiver.h
+++ b/include/IPC/zmq_receiver.h
@@ -1,6 +1,7 @@
 #ifndef _ZMQ_RECEIVER_H_
 #define _ZMQ_RECEIVER_H_
 
+#include "../utility.h"
 #include <string>
 #include <zmq.hpp>
 
@@ -10,8 +11,7 @@ class ZMQReceiver {
     zmq::socket_t socket;
 
   public:
-    ZMQReceiver() = delete;
-    ZMQReceiver(unsigned int port);
+    ZMQReceiver();
     std::string receive();
 };
 

--- a/include/IPC/zmq_sender.h
+++ b/include/IPC/zmq_sender.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <zmq.hpp>
+#include "../utility.h"
 
 class ZMQSender {
     unsigned int port;
@@ -10,8 +11,7 @@ class ZMQSender {
     zmq::socket_t socket;
 
   public:
-    ZMQSender() = delete;
-    ZMQSender(unsigned int port);
+    ZMQSender();
     void send(const std::string& message);
 };
 

--- a/include/Peers/provider.h
+++ b/include/Peers/provider.h
@@ -22,7 +22,7 @@ class Provider : public Peer {
     ZMQReceiver zmq_receiver;
 
   public:
-    Provider(const char* port, std::string uuid, const char* zmq_port);
+    Provider(const char* port, std::string uuid);
     ~Provider() noexcept;
 
     void registerWithBootstrap();

--- a/main.cpp
+++ b/main.cpp
@@ -10,15 +10,11 @@ using namespace std;
 // comment testing
 
 int main(int argc, char* argv[]) {
-    const char *port = "8080", *zmq_port = "5555";
+    const char *port = "8080";
     string uuid = uuid::generate_uuid_v4();
 
     if (argc >= 2) {
         port = argv[1];
-    }
-
-    if (argc >= 3) {
-        zmq_port = argv[2];
     }
 
 #if defined(BOOTSTRAP)
@@ -27,13 +23,13 @@ int main(int argc, char* argv[]) {
     b.listen();
 #elif defined(PROVIDER)
     cout << "Running as provider on port " << port << "." << endl;
-    Provider p = Provider(port, uuid, zmq_port);
+    Provider p = Provider(port, uuid);
     p.registerWithBootstrap();
     p.listen();
 #elif defined(REQUESTER)
     cout << "Running as requester." << endl;
     Requester r = Requester(port);
-    int numRequestedWorkers = 3;
+    int numRequestedWorkers = 2;
 
     string requestType = "c";
     if (argc >= 3) {

--- a/sorting_python/sorting.py
+++ b/sorting_python/sorting.py
@@ -1,9 +1,8 @@
 import zmq
 
 # Set up the context and responder socket
-base_port = int(input("Enter the base port number: "))
-port_rec = base_port
-port_send = base_port + 1
+port_rec = int(input("Enter the ZMQ sender port number: "))
+port_send = int(input("Enter the ZMQ receiver port number: "))
 
 context = zmq.Context()
 responder = context.socket(zmq.REP)

--- a/src/IPC/zmq_receiver.cpp
+++ b/src/IPC/zmq_receiver.cpp
@@ -1,9 +1,11 @@
 #include "../../include/IPC/zmq_receiver.h"
 
-ZMQReceiver::ZMQReceiver(unsigned int port)
-    : port(port), context(1), socket(context, zmq::socket_type::rep) {
+ZMQReceiver::ZMQReceiver()
+    : context(1), socket(context, zmq::socket_type::rep) {
+    port = get_available_port();
     const std::string address = "tcp://*:" + std::to_string(port);
     socket.bind(address);
+    std::cout << "ZMQReceiver address: " << address << std::endl;
 }
 
 std::string ZMQReceiver::receive() {

--- a/src/IPC/zmq_sender.cpp
+++ b/src/IPC/zmq_sender.cpp
@@ -1,9 +1,10 @@
 #include "../../include/IPC/zmq_sender.h"
 
-ZMQSender::ZMQSender(unsigned int port)
-    : port(port), context(1), socket(context, zmq::socket_type::req) {
+ZMQSender::ZMQSender() : context(1), socket(context, zmq::socket_type::req) {
+    port = get_available_port();
     const std::string address = "tcp://localhost:" + std::to_string(port);
     socket.connect(address);
+    std::cout << "ZMQSender address: " << address << std::endl;
 }
 
 void ZMQSender::send(const std::string& message) {

--- a/src/Peers/provider.cpp
+++ b/src/Peers/provider.cpp
@@ -14,8 +14,8 @@
 
 using namespace std;
 
-Provider::Provider(const char* port, string uuid, const char* zmq_port)
-    : Peer(uuid), zmq_sender(stoi(zmq_port)), zmq_receiver(stoi(zmq_port) + 1) {
+Provider::Provider(const char* port, string uuid)
+    : Peer(uuid), zmq_sender(), zmq_receiver() {
     isBusy = false;
     isLocalBootstrap = false;
 


### PR DESCRIPTION
Generating random port numbers to set up the ZMQ receiver and the sender

Currently, the python sorting example queries the user for these generated ports. The next PR will spin up the python process and pass in the generated ports (so no user input is required)