### PR TITLE
Automatically spawn python child process from provider C++ code

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -62,9 +62,8 @@ cc_binary(
     name = "provider",
     srcs = ["main.cpp"],
     defines = ["PROVIDER=1"] + local_defines,                    
-    deps = [
-        ":src_files",
-    ],
+    deps = [":src_files"],
+    data = ["sorting_python/sorting.py"]
 )
 
 cc_binary(
@@ -72,6 +71,11 @@ cc_binary(
     srcs = ["main.cpp"],
     defines = ["REQUESTER=1"] + local_defines,                    
     deps = [":src_files"],
+)
+
+py_binary(
+    name = "sorting",
+    srcs = ["sorting_python/sorting.py"],
 )
 
 ################################# tests BUILD target #################################

--- a/include/IPC/zmq_receiver.h
+++ b/include/IPC/zmq_receiver.h
@@ -13,6 +13,7 @@ class ZMQReceiver {
   public:
     ZMQReceiver();
     std::string receive();
+    unsigned int getPort() const;
 };
 
 #endif // _ZMQ_RECEIVER_H_

--- a/include/IPC/zmq_sender.h
+++ b/include/IPC/zmq_sender.h
@@ -13,6 +13,7 @@ class ZMQSender {
   public:
     ZMQSender();
     void send(const std::string& message);
+    unsigned int getPort() const;
 };
 
 #endif // _ZMQ_SENDER_H_

--- a/sorting_python/sorting.py
+++ b/sorting_python/sorting.py
@@ -1,8 +1,9 @@
 import zmq
+import sys
 
 # Set up the context and responder socket
-port_rec = int(input("Enter the ZMQ sender port number: "))
-port_send = int(input("Enter the ZMQ receiver port number: "))
+port_rec = int(sys.argv[1])
+port_send = int(sys.argv[2])
 
 context = zmq.Context()
 responder = context.socket(zmq.REP)

--- a/src/IPC/zmq_receiver.cpp
+++ b/src/IPC/zmq_receiver.cpp
@@ -19,3 +19,7 @@ std::string ZMQReceiver::receive() {
 
     return zmq_msg.to_string();
 }
+
+unsigned int ZMQReceiver::getPort() const {
+    return port;
+}

--- a/src/IPC/zmq_sender.cpp
+++ b/src/IPC/zmq_sender.cpp
@@ -15,3 +15,7 @@ void ZMQSender::send(const std::string& message) {
     zmq::message_t reply;
     socket.recv(reply, zmq::recv_flags::none);
 }
+
+unsigned int ZMQSender::getPort() const {
+    return port;
+}

--- a/src/Peers/provider.cpp
+++ b/src/Peers/provider.cpp
@@ -81,11 +81,13 @@ void Provider::listen() {
 
         try {
             // Spin up python script child process
+            const char* python_env = std::getenv("PYTHON_INTERPRETER");
+            std::string python_interpreter = python_env ? python_env : "/usr/bin/python3";
             std::string script_path = "sorting_python/sorting.py";
             std::vector<std::string> args{
                 std::to_string(zmq_sender.getPort()),
                 std::to_string(zmq_receiver.getPort())};
-            boost::process::child python_script("/usr/bin/env", "python3", script_path, args);
+            boost::process::child python_script(python_interpreter, script_path, args);
 
             // Process P2P communication
             if (task->getLeaderUuid() == uuid) {

--- a/src/Peers/provider.cpp
+++ b/src/Peers/provider.cpp
@@ -7,6 +7,7 @@
 #include "../../include/utility.h"
 
 #include <algorithm>
+#include <boost/process.hpp>
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
@@ -78,10 +79,30 @@ void Provider::listen() {
             server->closeConn();
         }
 
-        if (task->getLeaderUuid() == uuid) {
-            leaderHandleTaskRequest(requesterIpAddr);
-        } else {
-            followerHandleTaskRequest();
+        try {
+            // Spin up python script child process
+            std::string script_path = "sorting_python/sorting.py";
+            std::vector<std::string> args{
+                std::to_string(zmq_sender.getPort()),
+                std::to_string(zmq_receiver.getPort())};
+            boost::process::child python_script("/usr/bin/env", "python3", script_path, args);
+
+            // Process P2P communication
+            if (task->getLeaderUuid() == uuid) {
+                leaderHandleTaskRequest(requesterIpAddr);
+            } else {
+                followerHandleTaskRequest();
+            }
+
+            // Wait for python script to terminate
+            python_script.wait();
+
+            int exit_code = python_script.exit_code();
+            if (exit_code != 0) {
+                std::cout << "Error: Python child process exited with code: " << exit_code << std::endl;
+            }
+        } catch (const std::exception& e) {
+            std::cerr << "Exception: " << e.what() << std::endl;
         }
     }
 }


### PR DESCRIPTION
Modified provider C++ code to use the autogenerated ZMQ sender/receiver ports to spin up the python child process using boost. Every time the provider starts working on a task request, a python child process is created and terminated.