### PR TITLE
Send image glob index files from requester to providers and their python workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ MODULE.bazel.lock
 bazel-CloudMesh
 
 data/*
+subtaskIndex_*.txt
 third_party/cppzmq*
 third_party/libzmq*
 

--- a/include/Peers/provider.h
+++ b/include/Peers/provider.h
@@ -32,7 +32,7 @@ class Provider : public Peer {
     void followerHandleTaskRequest();
     void processData();
     void processWorkload(); // worker function to manipulate the TaskRequest
-    std::vector<int>
+    std::string
     ingestTrainingData(); // worker function to load training data into memory
     TaskResponse aggregateResults(std::vector<std::vector<int>> followerData);
 };

--- a/include/utility.h
+++ b/include/utility.h
@@ -34,7 +34,7 @@ namespace fs = std::filesystem;
 /*
  * Defines the data location of training files.
  */
-const std::string DATA_DIR = "data";
+const std::string DATA_DIR = "CIFAR10/train";
 
 struct IpAddress {
     std::string host;

--- a/main.cpp
+++ b/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]) {
 
     if (requestType == "c") {
         TaskRequest request =
-            TaskRequest(numRequestedWorkers, ".*subtaskData_.*\\.txt$",
+            TaskRequest(numRequestedWorkers, ".*\\.jpg$",
                         TaskRequest::GLOB_PATTERN);
         r.setTaskRequest(request);
         // sends the task request to the leader and provider peers

--- a/proto/payload.proto
+++ b/proto/payload.proto
@@ -43,6 +43,10 @@ message TaskRequest {
     }
 }
 
+message TrainingData {
+    string training_data_index_filename = 1;
+}
+
 message TaskResponse { repeated int32 trainingData = 1; }
 
 message Acknowledgement {}

--- a/src/Peers/requester.cpp
+++ b/src/Peers/requester.cpp
@@ -7,6 +7,9 @@
 #include "../../include/RequestResponse/task_request.h"
 #include "../../include/utility.h"
 
+#include <algorithm>
+#include <random>
+
 using namespace std;
 
 Requester::Requester(const char* port) : Peer() {
@@ -67,6 +70,11 @@ void Requester::divideTask() {
     // obtain list of training files
     vector<string> trainingFiles = queuedTask.getTrainingDataFiles();
     cout << "Found " << trainingFiles.size() << " training files" << endl;
+
+    // shuffle training files for even distribution after division
+    std::random_device rd; // Seed generator
+    std::mt19937 g(rd());  // Mersenne Twister engine
+    std::shuffle(trainingFiles.begin(), trainingFiles.end(), g);
 
     // divide the vector into subvectors
     int numSubtasks = queuedTask.getNumWorkers();


### PR DESCRIPTION
Changes:
- Use CIFAR10 train dataset images and modified the GLOB regex to match the image files
- Shuffle training data in requester before dividing among providers to ensure even distribution of training data
- Created simple `TrainingData` proto that just has a field for `training_data_index_filename`
- Sends the `TrainingData` proto to the python worker over zmq

ToDo:
- Parse the `TrainingData` proto on the python worker side
- Handle different task result from python worker (will not be a vector of integers?)